### PR TITLE
build: create cjs and esm output

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,5 +13,8 @@
     "@cosmjs/proto-signing": "^0.28.7",
     "@cosmjs/stargate": "^0.28.7",
     "long": "^5.2.0"
+  },
+  "devDependencies": {
+    "typescript": "^4.7.4"
   }
 }

--- a/package.json
+++ b/package.json
@@ -3,9 +3,13 @@
   "description": "JS Interface for the Kujira Blockchain",
   "version": "0.0.1",
   "license": "MIT",
-  "main": "lib/index.js",
+  "main": "./lib/cjs/index.js",
+  "module": "./lib/esm/index.js",
+  "files": [
+    "lib/"
+  ],
   "scripts": {
-    "build": "tsc"
+    "build": "tsc -p tsconfig.json && tsc -p tsconfig-cjs.json"
   },
   "dependencies": {
     "@cosmjs/cosmwasm-stargate": "^0.28.7",

--- a/tsconfig-cjs.json
+++ b/tsconfig-cjs.json
@@ -1,0 +1,7 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "module": "CommonJS",
+    "outDir": "./lib/cjs"
+  },
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -4,7 +4,7 @@
     "lib": ["ES2021", "DOM"],
     "module": "ES2020",
     "declaration": true,
-    "outDir": "./lib",
+    "outDir": "./lib/esm",
     "strict": true,
     "moduleResolution": "node",
     "allowSyntheticDefaultImports": true

--- a/yarn.lock
+++ b/yarn.lock
@@ -604,6 +604,11 @@ symbol-observable@^2.0.3:
   resolved "https://registry.yarnpkg.com/symbol-observable/-/symbol-observable-2.0.3.tgz#5b521d3d07a43c351055fa43b8355b62d33fd16a"
   integrity sha512-sQV7phh2WCYAn81oAkakC5qjq2Ml0g8ozqz03wOGnx9dDlG1de6yrF+0RAzSJD8fPUow3PTSMf2SAbOGxb93BA==
 
+typescript@^4.7.4:
+  version "4.7.4"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.7.4.tgz#1a88596d1cf47d59507a1bcdfb5b9dfe4d488235"
+  integrity sha512-C0WQT0gezHuw6AdY1M2jxUO83Rjf0HP7Sk1DtXj6j1EwkQNZrHAg2XPWlq62oqEhYvONq5pkC2Y9oPljWToLmQ==
+
 util-deprecate@^1.0.1:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/util-deprecate/-/util-deprecate-1.0.2.tgz#450d4dc9fa70de732762fbd2d4a28981419a0ccf"


### PR DESCRIPTION
# 🛑 Beware
The `lib` output has not been updated yet, it generates a lot of noise and makes the review harder.

Review first, then I can push an updated `lib` folder

This PR will:

- Add typescript as dev dependency to avoid depending on local installs of `tsc` 
- Update typescript configs to output both in `ESM` and `CJS` format

The latter is required in order to support consuming the package from nodejs/typescript