### PR TITLE
doc: add prefix to 'fromMnemonic'

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ import { DirectSecp256k1HdWallet } from "@cosmjs/proto-signing";
 const RPC_ENDPOINT = "https://rpc-harpoon.kujira.app";
 const MNEMONIC = "...";
 
-const signer = await DirectSecp256k1HdWallet.fromMnemonic(MNEMONIC);
+const signer = await DirectSecp256k1HdWallet.fromMnemonic(MNEMONIC, { prefix: 'kujira' });
 
 const client = await SigningStargateClient.connectWithSigner(
   RPC_ENDPOINT,


### PR DESCRIPTION
If the parameter is omitted, the following error message is

`invalid Bech32 prefix; expected kujira, got cosmos: invalid request.`