### PR TITLE
add calc to pair type

### DIFF
--- a/lib/cjs/pairs.d.ts
+++ b/lib/cjs/pairs.d.ts
@@ -17,6 +17,7 @@ export declare type Pair = {
     multiswap: boolean;
     pool?: string;
     queue?: string;
+    calc?: string;
 };
 export declare const STAKING: {
     "harpoon-4": string;

--- a/lib/cjs/pairs.js
+++ b/lib/cjs/pairs.js
@@ -17,6 +17,7 @@ exports.PAIRS = [
         decimalDelta: 0,
         multiswap: true,
         pool: "kujira1sx99fxy4lqx0nv3ys86tkdrch82qygxyec5c8dxsk9raz4at5zpq72gypx",
+        calc: "kujira1e6fjnq7q20sh9cca76wdkfg69esha5zn53jjewrtjgm4nktk824stzyysu"
     },
     {
         address: "kujira18v47nqmhvejx3vc498pantg8vr435xa0rt6x0m6kzhp6yuqmcp8s4x8j2c",
@@ -26,6 +27,7 @@ exports.PAIRS = [
         decimalDelta: 0,
         multiswap: true,
         pool: "kujira13y8hs83sk0la7na2w5g5nzrnjjpnkvmd7e87yd35g8dcph7dn0ksenay2a",
+        calc: "kujira1e6fjnq7q20sh9cca76wdkfg69esha5zn53jjewrtjgm4nktk824stzyysu"
     },
     {
         address: "kujira193dzcmy7lwuj4eda3zpwwt9ejal00xva0vawcvhgsyyp5cfh6jyq66wfrf",
@@ -35,6 +37,7 @@ exports.PAIRS = [
         decimalDelta: 0,
         multiswap: true,
         pool: "kujira1g9xcvvh48jlckgzw8ajl6dkvhsuqgsx2g8u3v0a6fx69h7f8hffqaqu36t",
+        calc: "kujira1e6fjnq7q20sh9cca76wdkfg69esha5zn53jjewrtjgm4nktk824stzyysu"
     },
     {
         address: "kujira1rwx6w02alc4kaz7xpyg3rlxpjl4g63x5jq292mkxgg65zqpn5llq202vh5",
@@ -174,6 +177,7 @@ exports.PAIRS = [
         decimalDelta: 0,
         multiswap: true,
         pool: "kujira14wv3whn3v9sgf8r0dm7a46v7m7pukhs87x73e0ude3ktuzztfj9qxndumz",
+        calc: "kujira1e6fjnq7q20sh9cca76wdkfg69esha5zn53jjewrtjgm4nktk824stzyysu"
     },
     {
         address: "kujira1hulx7cgvpfcvg83wk5h96sedqgn72n026w6nl47uht554xhvj9nsra5j5u",
@@ -368,6 +372,7 @@ exports.PAIRS = [
         multiswap: true,
         pool: "kujira19kxd9sqk09zlzqfykk7tzyf70hl009hkekufq8q0ud90ejtqvvxs8xg5cq",
         queue: "kujira19m8s6ru20s62ygyr5qdng8yw2la3lemy8rgt55q38hyl57taxmvsgfre6m",
+        calc: "kujira18g945dfs4jp8zfu428zfkjz0r4sasnxnsnye5m6dznvmgrlcecpsyrwp7c"
     },
     {
         address: "kujira10qt8wg0n7z740ssvf3urmvgtjhxpyp74hxqvqt7z226gykuus7eqedsw8k",

--- a/lib/esm/pairs.d.ts
+++ b/lib/esm/pairs.d.ts
@@ -17,6 +17,7 @@ export declare type Pair = {
     multiswap: boolean;
     pool?: string;
     queue?: string;
+    calc?: string;
 };
 export declare const STAKING: {
     "harpoon-4": string;

--- a/lib/esm/pairs.js
+++ b/lib/esm/pairs.js
@@ -14,6 +14,7 @@ export const PAIRS = [
         decimalDelta: 0,
         multiswap: true,
         pool: "kujira1sx99fxy4lqx0nv3ys86tkdrch82qygxyec5c8dxsk9raz4at5zpq72gypx",
+        calc: "kujira1e6fjnq7q20sh9cca76wdkfg69esha5zn53jjewrtjgm4nktk824stzyysu"
     },
     {
         address: "kujira18v47nqmhvejx3vc498pantg8vr435xa0rt6x0m6kzhp6yuqmcp8s4x8j2c",
@@ -23,6 +24,7 @@ export const PAIRS = [
         decimalDelta: 0,
         multiswap: true,
         pool: "kujira13y8hs83sk0la7na2w5g5nzrnjjpnkvmd7e87yd35g8dcph7dn0ksenay2a",
+        calc: "kujira1e6fjnq7q20sh9cca76wdkfg69esha5zn53jjewrtjgm4nktk824stzyysu"
     },
     {
         address: "kujira193dzcmy7lwuj4eda3zpwwt9ejal00xva0vawcvhgsyyp5cfh6jyq66wfrf",
@@ -32,6 +34,7 @@ export const PAIRS = [
         decimalDelta: 0,
         multiswap: true,
         pool: "kujira1g9xcvvh48jlckgzw8ajl6dkvhsuqgsx2g8u3v0a6fx69h7f8hffqaqu36t",
+        calc: "kujira1e6fjnq7q20sh9cca76wdkfg69esha5zn53jjewrtjgm4nktk824stzyysu"
     },
     {
         address: "kujira1rwx6w02alc4kaz7xpyg3rlxpjl4g63x5jq292mkxgg65zqpn5llq202vh5",
@@ -171,6 +174,7 @@ export const PAIRS = [
         decimalDelta: 0,
         multiswap: true,
         pool: "kujira14wv3whn3v9sgf8r0dm7a46v7m7pukhs87x73e0ude3ktuzztfj9qxndumz",
+        calc: "kujira1e6fjnq7q20sh9cca76wdkfg69esha5zn53jjewrtjgm4nktk824stzyysu"
     },
     {
         address: "kujira1hulx7cgvpfcvg83wk5h96sedqgn72n026w6nl47uht554xhvj9nsra5j5u",
@@ -365,6 +369,7 @@ export const PAIRS = [
         multiswap: true,
         pool: "kujira19kxd9sqk09zlzqfykk7tzyf70hl009hkekufq8q0ud90ejtqvvxs8xg5cq",
         queue: "kujira19m8s6ru20s62ygyr5qdng8yw2la3lemy8rgt55q38hyl57taxmvsgfre6m",
+        calc: "kujira18g945dfs4jp8zfu428zfkjz0r4sasnxnsnye5m6dznvmgrlcecpsyrwp7c"
     },
     {
         address: "kujira10qt8wg0n7z740ssvf3urmvgtjhxpyp74hxqvqt7z226gykuus7eqedsw8k",

--- a/src/pairs.ts
+++ b/src/pairs.ts
@@ -19,6 +19,7 @@ export type Pair = {
   multiswap: boolean;
   pool?: string;
   queue?: string;
+  calc?: string;
 };
 
 export const STAKING = {
@@ -38,6 +39,7 @@ export const PAIRS: Pair[] = [
     decimalDelta: 0,
     multiswap: true,
     pool: "kujira1sx99fxy4lqx0nv3ys86tkdrch82qygxyec5c8dxsk9raz4at5zpq72gypx",
+    calc: "kujira1e6fjnq7q20sh9cca76wdkfg69esha5zn53jjewrtjgm4nktk824stzyysu"
   },
 
   {
@@ -49,6 +51,7 @@ export const PAIRS: Pair[] = [
     decimalDelta: 0,
     multiswap: true,
     pool: "kujira13y8hs83sk0la7na2w5g5nzrnjjpnkvmd7e87yd35g8dcph7dn0ksenay2a",
+    calc: "kujira1e6fjnq7q20sh9cca76wdkfg69esha5zn53jjewrtjgm4nktk824stzyysu"
   },
   {
     address:
@@ -59,6 +62,7 @@ export const PAIRS: Pair[] = [
     decimalDelta: 0,
     multiswap: true,
     pool: "kujira1g9xcvvh48jlckgzw8ajl6dkvhsuqgsx2g8u3v0a6fx69h7f8hffqaqu36t",
+    calc: "kujira1e6fjnq7q20sh9cca76wdkfg69esha5zn53jjewrtjgm4nktk824stzyysu"
   },
   {
     address:
@@ -243,6 +247,7 @@ export const PAIRS: Pair[] = [
     decimalDelta: 0,
     multiswap: true,
     pool: "kujira14wv3whn3v9sgf8r0dm7a46v7m7pukhs87x73e0ude3ktuzztfj9qxndumz",
+    calc: "kujira1e6fjnq7q20sh9cca76wdkfg69esha5zn53jjewrtjgm4nktk824stzyysu"
   },
 
   {
@@ -500,6 +505,7 @@ export const PAIRS: Pair[] = [
     multiswap: true,
     pool: "kujira19kxd9sqk09zlzqfykk7tzyf70hl009hkekufq8q0ud90ejtqvvxs8xg5cq",
     queue: "kujira19m8s6ru20s62ygyr5qdng8yw2la3lemy8rgt55q38hyl57taxmvsgfre6m",
+    calc: "kujira18g945dfs4jp8zfu428zfkjz0r4sasnxnsnye5m6dznvmgrlcecpsyrwp7c"
   },
   {
     address:


### PR DESCRIPTION
# CALC DCA pairs
The purpose of this PR is to enable the FIN frontend to show pairs that are supported by CALC DCA vaults
- Add `calc` property to Pair type to denote pairs that are supported on calc
- Add mainnet contract address to supported calc pairs
- Add testnet contract address to supported calc pairs